### PR TITLE
Move all enums into separate header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(parseagle STATIC
     # Headers
     parseagle/common/circle.h
     parseagle/common/domelement.h
+    parseagle/common/enums.h
     parseagle/common/point.h
     parseagle/common/polygon.h
     parseagle/common/rectangle.h

--- a/parseagle.pro
+++ b/parseagle.pro
@@ -39,6 +39,7 @@ SOURCES += \
 HEADERS += \
     parseagle/common/circle.h \
     parseagle/common/domelement.h \
+    parseagle/common/enums.h \
     parseagle/common/point.h \
     parseagle/common/polygon.h \
     parseagle/common/rectangle.h \

--- a/parseagle/common/enums.h
+++ b/parseagle/common/enums.h
@@ -1,0 +1,131 @@
+#ifndef PARSEAGLE_ENUMS_H
+#define PARSEAGLE_ENUMS_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+enum class Alignment
+{
+    Unknown,  // Failed to parse XML attribute.
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    CenterLeft,
+    Center,
+    CenterRight,
+    TopLeft,
+    TopCenter,
+    TopRight,
+};
+
+inline Alignment parseAlignment(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "bottom-left") {
+        return Alignment::BottomLeft;
+    } else if (s == "bottom-center") {
+        return Alignment::BottomCenter;
+    } else if (s == "bottom-right") {
+        return Alignment::BottomRight;
+    } else if (s == "center-left") {
+        return Alignment::CenterLeft;
+    } else if (s == "center") {
+        return Alignment::Center;
+    } else if (s == "center-right") {
+        return Alignment::CenterRight;
+    } else if (s == "top-left") {
+        return Alignment::TopLeft;
+    } else if (s == "top-center") {
+        return Alignment::TopCenter;
+    } else if (s == "top-right") {
+        return Alignment::TopRight;
+    } else if (errors) {
+        errors->append("Unknown alignment: " + s);
+    }
+    return Alignment::Unknown;
+}
+
+enum class GateAddLevel
+{
+    Unknown,  // Failed to parse XML attribute.
+    Must,
+    Can,
+    Next,
+    Request,
+    Always,
+};
+
+inline GateAddLevel parseGateAddLevel(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "must") {
+        return GateAddLevel::Must;
+    } else if (s == "can") {
+        return GateAddLevel::Can;
+    } else if (s == "next") {
+        return GateAddLevel::Next;
+    } else if (s == "request") {
+        return GateAddLevel::Request;
+    } else if (s == "always") {
+        return GateAddLevel::Always;
+    } else if (errors) {
+        errors->append("Unknown gate add level: " + s);
+    }
+    return GateAddLevel::Unknown;
+}
+
+enum class PadShape
+{
+    Unknown,  // Failed to parse XML attribute.
+    Square,
+    Round,
+    Octagon,
+    Long,
+    Offset,
+};
+
+inline PadShape parsePadShape(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "square") {
+        return PadShape::Square;
+    } else if (s == "round") {
+        return PadShape::Round;
+    } else if (s == "octagon") {
+        return PadShape::Octagon;
+    } else if (s == "long") {
+        return PadShape::Long;
+    } else if (s == "offset") {
+        return PadShape::Offset;
+    } else if (errors) {
+        errors->append("Unknown pad shape: " + s);
+    }
+    return PadShape::Unknown;
+}
+
+enum class PinLength
+{
+    Unknown,  // Failed to parse XML attribute.
+    Point,
+    Short,
+    Middle,
+    Long,
+};
+
+inline PinLength parsePinLength(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "point") {
+        return PinLength::Point;
+    } else if (s == "short") {
+        return PinLength::Short;
+    } else if (s == "middle") {
+        return PinLength::Middle;
+    } else if (s == "long") {
+        return PinLength::Long;
+    } else if (errors) {
+        errors->append("Unknown pin length: " + s);
+    }
+    return PinLength::Unknown;
+}
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_ENUMS_H

--- a/parseagle/common/text.cpp
+++ b/parseagle/common/text.cpp
@@ -13,32 +13,8 @@ Text::Text(const DomElement& root, QStringList* errors)
     if (root.hasAttribute("rot")) {
         mRotation = Rotation(root.getAttributeAsString("rot"));
     }
-    mAlignment = Alignment::Unknown;
     if (root.hasAttribute("align")) {
-        QString alignStr = root.getAttributeAsString("align");
-        if (alignStr == "bottom-left") {
-            mAlignment = Alignment::BottomLeft;
-        } else if (alignStr == "bottom-center") {
-            mAlignment = Alignment::BottomCenter;
-        } else if (alignStr == "bottom-right") {
-            mAlignment = Alignment::BottomRight;
-        } else if (alignStr == "center-left") {
-            mAlignment = Alignment::CenterLeft;
-        } else if (alignStr == "center") {
-            mAlignment = Alignment::Center;
-        } else if (alignStr == "center-right") {
-            mAlignment = Alignment::CenterRight;
-        } else if (alignStr == "top-left") {
-            mAlignment = Alignment::TopLeft;
-        } else if (alignStr == "top-center") {
-            mAlignment = Alignment::TopCenter;
-        } else if (alignStr == "top-right") {
-            mAlignment = Alignment::TopRight;
-        } else if (errors) {
-            errors->append("Unknown text alignment: " + alignStr);
-        }
-    } else {
-        mAlignment = Alignment::BottomLeft;
+        mAlignment = parseAlignment(root.getAttributeAsString("align"), errors);
     }
     mValue = root.getText();
 }

--- a/parseagle/common/text.h
+++ b/parseagle/common/text.h
@@ -2,6 +2,7 @@
 #define PARSEAGLE_TEXT_H
 
 #include <QtCore>
+#include "../common/enums.h"
 #include "../common/point.h"
 #include "../common/rotation.h"
 
@@ -14,18 +15,7 @@ class Text final
     public:
 
         // Types
-        enum class Alignment {
-            Unknown,  // Failed to parse XML attribute.
-            BottomLeft,
-            BottomCenter,
-            BottomRight,
-            CenterLeft,
-            Center,
-            CenterRight,
-            TopLeft,
-            TopCenter,
-            TopRight,
-        };
+        using Alignment = parseagle::Alignment;  // [DEPRECATED] Backwards compatibility
 
         // Constructors / Destructor
         Text() = delete;
@@ -46,7 +36,7 @@ class Text final
         double mSize;
         Point mPosition;
         Rotation mRotation;
-        Alignment mAlignment;
+        Alignment mAlignment = Alignment::BottomLeft;
         QString mValue;
 };
 

--- a/parseagle/deviceset/gate.cpp
+++ b/parseagle/deviceset/gate.cpp
@@ -10,25 +10,8 @@ Gate::Gate(const DomElement& root, QStringList* errors)
     mSymbol = root.getAttributeAsString("symbol");
     mPosition.x = root.getAttributeAsDouble("x");
     mPosition.y = root.getAttributeAsDouble("y");
-
-    mAddLevel = AddLevel::Unknown;
     if (root.hasAttribute("addlevel")) {
-        QString addLevelStr = root.getAttributeAsString("addlevel");
-        if (addLevelStr == "must") {
-            mAddLevel = AddLevel::Must;
-        } else if (addLevelStr == "can") {
-            mAddLevel = AddLevel::Can;
-        } else if (addLevelStr == "next") {
-            mAddLevel = AddLevel::Next;
-        } else if (addLevelStr == "request") {
-            mAddLevel = AddLevel::Request;
-        } else if (addLevelStr == "always") {
-            mAddLevel = AddLevel::Always;
-        } else if (errors) {
-            errors->append("Unknown gate addlevel: " + addLevelStr);
-        }
-    } else {
-        mAddLevel = AddLevel::Next;
+        mAddLevel = parseGateAddLevel(root.getAttributeAsString("addlevel"), errors);
     }
 }
 

--- a/parseagle/deviceset/gate.h
+++ b/parseagle/deviceset/gate.h
@@ -2,6 +2,7 @@
 #define PARSEAGLE_GATE_H
 
 #include <QtCore>
+#include "../common/enums.h"
 #include "../common/point.h"
 
 namespace parseagle {
@@ -13,14 +14,7 @@ class Gate final
     public:
 
         // Types
-        enum class AddLevel {
-            Unknown,  // Failed to parse XML attribute.
-            Must,
-            Can,
-            Next,
-            Request,
-            Always,
-        };
+        using AddLevel = parseagle::GateAddLevel;  // [DEPRECATED] Backwards compatibility
 
         // Constructors / Destructor
         Gate() = delete;
@@ -31,14 +25,14 @@ class Gate final
         QString getName() const noexcept {return mName;}
         QString getSymbol() const noexcept {return mSymbol;}
         const Point& getPosition() const noexcept {return mPosition;}
-        AddLevel getAddLevel() const noexcept {return mAddLevel;}
+        GateAddLevel getAddLevel() const noexcept {return mAddLevel;}
 
 
     private:
         QString mName;
         QString mSymbol;
         Point mPosition;
-        AddLevel mAddLevel;
+        GateAddLevel mAddLevel = GateAddLevel::Next;
 };
 
 } // namespace parseagle

--- a/parseagle/package/thtpad.cpp
+++ b/parseagle/package/thtpad.cpp
@@ -17,26 +17,9 @@ ThtPad::ThtPad(const DomElement& root, QStringList* errors)
         mOuterDiameter = 0.0;
     }
 
-    mShape = Shape::Unknown;
     if (root.hasAttribute("shape")) {
-        QString shapeStr = root.getAttributeAsString("shape");
-        if (shapeStr == "square") {
-            mShape = Shape::Square;
-        } else if (shapeStr == "octagon") {
-            mShape = Shape::Octagon;
-        } else if (shapeStr == "round") {
-            mShape = Shape::Round;
-        } else if (shapeStr == "long") {
-            mShape = Shape::Long;
-        } else if (shapeStr == "offset") {
-            mShape = Shape::Offset;
-        } else if (errors) {
-            errors->append("Unknown pad shape: " + shapeStr);
-        }
-    } else {
-        mShape = Shape::Round;
+        mShape = parsePadShape(root.getAttributeAsString("shape"), errors);
     }
-
     if (root.hasAttribute("rot")) {
         mRotation = Rotation(root.getAttributeAsString("rot"));
     }

--- a/parseagle/package/thtpad.h
+++ b/parseagle/package/thtpad.h
@@ -2,6 +2,7 @@
 #define PARSEAGLE_THTPAD_H
 
 #include <QtCore>
+#include "../common/enums.h"
 #include "../common/point.h"
 #include "../common/rotation.h"
 
@@ -14,14 +15,7 @@ class ThtPad final
     public:
 
         // Types
-        enum class Shape {
-            Unknown,  // Failed to parse XML attribute.
-            Square,
-            Octagon,
-            Round,
-            Long,
-            Offset,
-        };
+        using Shape = parseagle::PadShape;  // [DEPRECATED] Backwards compatibility
 
         // Constructors / Destructor
         ThtPad() = delete;
@@ -33,7 +27,7 @@ class ThtPad final
         const Point& getPosition() const noexcept {return mPosition;}
         double getDrillDiameter() const noexcept {return mDrillDiameter;}
         double getOuterDiameter() const noexcept {return mOuterDiameter;}
-        Shape getShape() const noexcept {return mShape;}
+        PadShape getShape() const noexcept {return mShape;}
         const Rotation& getRotation() const noexcept {return mRotation;}
 
 
@@ -42,7 +36,7 @@ class ThtPad final
         Point mPosition;
         double mDrillDiameter;
         double mOuterDiameter;
-        Shape mShape;
+        PadShape mShape = PadShape::Round;
         Rotation mRotation;
 };
 

--- a/parseagle/symbol/pin.cpp
+++ b/parseagle/symbol/pin.cpp
@@ -9,25 +9,9 @@ Pin::Pin(const DomElement& root, QStringList* errors)
     mName = root.getAttributeAsString("name");
     mPosition.x = root.getAttributeAsDouble("x");
     mPosition.y = root.getAttributeAsDouble("y");
-
-    mLength = Length::Unknown;
     if (root.hasAttribute("length")) {
-        QString lengthStr = root.getAttributeAsString("length");
-        if (lengthStr == "point") {
-            mLength = Length::Point;
-        } else if (lengthStr == "short") {
-            mLength = Length::Short;
-        } else if (lengthStr == "middle") {
-            mLength = Length::Middle;
-        } else if (lengthStr == "long") {
-            mLength = Length::Long;
-        } else if (errors) {
-            errors->append("Unknown pin length: " + lengthStr);
-        }
-    } else {
-        mLength = Length::Long;
+        mLength = parsePinLength(root.getAttributeAsString("length"), errors);
     }
-
     if (root.hasAttribute("rot")) {
         mRotation = Rotation(root.getAttributeAsString("rot"));
     }
@@ -40,11 +24,11 @@ Pin::~Pin() noexcept
 double Pin::getLengthInMillimeters() const noexcept
 {
     switch (mLength) {
-        case Length::Point:     return 0.0;
-        case Length::Short:     return 2.54;
-        case Length::Middle:    return 5.08;
-        case Length::Long:      return 7.62;
-        default:                return 0.0;
+        case PinLength::Point:     return 0.0;
+        case PinLength::Short:     return 2.54;
+        case PinLength::Middle:    return 5.08;
+        case PinLength::Long:      return 7.62;
+        default:                   return 0.0;
     }
 }
 

--- a/parseagle/symbol/pin.h
+++ b/parseagle/symbol/pin.h
@@ -2,6 +2,7 @@
 #define PARSEAGLE_PIN_H
 
 #include <QtCore>
+#include "../common/enums.h"
 #include "../common/point.h"
 #include "../common/rotation.h"
 
@@ -14,13 +15,7 @@ class Pin final
     public:
 
         // Types
-        enum class Length {
-            Unknown,  // Failed to parse XML attribute.
-            Point,
-            Short,
-            Middle,
-            Long,
-        };
+        using Length = parseagle::PinLength;  // [DEPRECATED] Backwards compatibility
 
         // Constructors / Destructor
         Pin() = delete;
@@ -30,7 +25,7 @@ class Pin final
         // Getters
         QString getName() const noexcept {return mName;}
         const Point& getPosition() const noexcept {return mPosition;}
-        Length getLength() const noexcept {return mLength;}
+        PinLength getLength() const noexcept {return mLength;}
         double getLengthInMillimeters() const noexcept;
         const Rotation& getRotation() const noexcept {return mRotation;}
 
@@ -38,7 +33,7 @@ class Pin final
     private:
         QString mName;
         Point mPosition;
-        Length mLength;
+        PinLength mLength = PinLength::Long;
         Rotation mRotation;
 };
 


### PR DESCRIPTION
To allow sharing them between multiple classes.

Added `using` statements to keep the old enum types for backwards compatibility.