### PR TITLE
Point: Implement comparison oparators

### DIFF
--- a/parseagle/common/point.h
+++ b/parseagle/common/point.h
@@ -6,6 +6,9 @@ namespace parseagle {
 struct Point {
     double x;
     double y;
+
+    bool operator==(const Point& rhs) const noexcept {return (x == rhs.x) && (y == rhs.y);}
+    bool operator!=(const Point& rhs) const noexcept {return !(*this == rhs);}
 };
 
 } // namespace parseagle


### PR DESCRIPTION
To attach wires/traces to pins/pads, it seems EAGLE just compares their coordinates and attaches them if they are at the same position. So as a user of this library I need to check `Point` objects for equality.