### PR TITLE
Add support for many more EAGLE objects/attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,19 @@ find_package(Qt5 5.2.0 COMPONENTS Core Xml REQUIRED)
 # Export library
 add_library(parseagle STATIC
     # Sources
+    parseagle/board/board.cpp
+    parseagle/board/contactref.cpp
+    parseagle/board/designrules.cpp
+    parseagle/board/element.cpp
+    parseagle/board/param.cpp
+    parseagle/board/signal.cpp
+    parseagle/board/via.cpp
+    parseagle/common/attribute.cpp
     parseagle/common/circle.cpp
+    parseagle/common/dimension.cpp
     parseagle/common/domelement.cpp
+    parseagle/common/frame.cpp
+    parseagle/common/grid.cpp
     parseagle/common/polygon.cpp
     parseagle/common/rectangle.cpp
     parseagle/common/rotation.cpp
@@ -37,13 +48,34 @@ add_library(parseagle STATIC
     parseagle/package/package.cpp
     parseagle/package/smtpad.cpp
     parseagle/package/thtpad.cpp
+    parseagle/schematic/bus.cpp
+    parseagle/schematic/instance.cpp
+    parseagle/schematic/label.cpp
+    parseagle/schematic/module.cpp
+    parseagle/schematic/net.cpp
+    parseagle/schematic/part.cpp
+    parseagle/schematic/pinref.cpp
+    parseagle/schematic/schematic.cpp
+    parseagle/schematic/segment.cpp
+    parseagle/schematic/sheet.cpp
     parseagle/symbol/pin.cpp
     parseagle/symbol/symbol.cpp
 
     # Headers
+    parseagle/board/board.h
+    parseagle/board/contactref.h
+    parseagle/board/designrules.h
+    parseagle/board/element.h
+    parseagle/board/param.h
+    parseagle/board/signal.h
+    parseagle/board/via.h
+    parseagle/common/attribute.h
     parseagle/common/circle.h
+    parseagle/common/dimension.h
     parseagle/common/domelement.h
     parseagle/common/enums.h
+    parseagle/common/frame.h
+    parseagle/common/grid.h
     parseagle/common/point.h
     parseagle/common/polygon.h
     parseagle/common/rectangle.h
@@ -60,6 +92,16 @@ add_library(parseagle STATIC
     parseagle/package/package.h
     parseagle/package/smtpad.h
     parseagle/package/thtpad.h
+    parseagle/schematic/bus.h
+    parseagle/schematic/instance.h
+    parseagle/schematic/label.h
+    parseagle/schematic/module.h
+    parseagle/schematic/net.h
+    parseagle/schematic/part.h
+    parseagle/schematic/pinref.h
+    parseagle/schematic/schematic.h
+    parseagle/schematic/segment.h
+    parseagle/schematic/sheet.h
     parseagle/symbol/pin.h
     parseagle/symbol/symbol.h
 )

--- a/parseagle.pro
+++ b/parseagle.pro
@@ -16,8 +16,19 @@ CONFIG -= app_bundle
 CONFIG += staticlib
 
 SOURCES += \
+    parseagle/board/board.cpp \
+    parseagle/board/contactref.cpp \
+    parseagle/board/designrules.cpp \
+    parseagle/board/element.cpp \
+    parseagle/board/param.cpp \
+    parseagle/board/signal.cpp \
+    parseagle/board/via.cpp \
+    parseagle/common/attribute.cpp \
     parseagle/common/circle.cpp \
+    parseagle/common/dimension.cpp \
     parseagle/common/domelement.cpp \
+    parseagle/common/frame.cpp \
+    parseagle/common/grid.cpp \
     parseagle/common/polygon.cpp \
     parseagle/common/rectangle.cpp \
     parseagle/common/rotation.cpp \
@@ -33,13 +44,34 @@ SOURCES += \
     parseagle/package/package.cpp \
     parseagle/package/smtpad.cpp \
     parseagle/package/thtpad.cpp \
+    parseagle/schematic/bus.cpp \
+    parseagle/schematic/instance.cpp \
+    parseagle/schematic/label.cpp \
+    parseagle/schematic/module.cpp \
+    parseagle/schematic/net.cpp \
+    parseagle/schematic/part.cpp \
+    parseagle/schematic/pinref.cpp \
+    parseagle/schematic/schematic.cpp \
+    parseagle/schematic/segment.cpp \
+    parseagle/schematic/sheet.cpp \
     parseagle/symbol/pin.cpp \
     parseagle/symbol/symbol.cpp \
 
 HEADERS += \
+    parseagle/board/board.h \
+    parseagle/board/contactref.h \
+    parseagle/board/designrules.h \
+    parseagle/board/element.h \
+    parseagle/board/param.h \
+    parseagle/board/signal.h \
+    parseagle/board/via.h \
+    parseagle/common/attribute.h \
     parseagle/common/circle.h \
+    parseagle/common/dimension.h \
     parseagle/common/domelement.h \
     parseagle/common/enums.h \
+    parseagle/common/frame.h \
+    parseagle/common/grid.h \
     parseagle/common/point.h \
     parseagle/common/polygon.h \
     parseagle/common/rectangle.h \
@@ -56,6 +88,16 @@ HEADERS += \
     parseagle/package/package.h \
     parseagle/package/smtpad.h \
     parseagle/package/thtpad.h \
+    parseagle/schematic/bus.h \
+    parseagle/schematic/instance.h \
+    parseagle/schematic/label.h \
+    parseagle/schematic/module.h \
+    parseagle/schematic/net.h \
+    parseagle/schematic/part.h \
+    parseagle/schematic/pinref.h \
+    parseagle/schematic/schematic.h \
+    parseagle/schematic/segment.h \
+    parseagle/schematic/sheet.h \
     parseagle/symbol/pin.h \
     parseagle/symbol/symbol.h \
 

--- a/parseagle/board/board.cpp
+++ b/parseagle/board/board.cpp
@@ -1,0 +1,87 @@
+#include <QtCore>
+#include "board.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Board::Board(const QString& filepath, QStringList* errors)
+{
+    QFile file(filepath);
+    if (!file.exists()) {
+        throw std::runtime_error("File does not exist: " + filepath.toStdString());
+    }
+    if (!file.open(QIODevice::ReadOnly)) {
+        throw std::runtime_error("Cannot open file " + filepath.toStdString() +
+                                 ": " + file.errorString().toStdString());
+    }
+    load(file.readAll(), errors);
+}
+
+Board::Board(const QByteArray& content, QStringList* errors)
+{
+    load(content, errors);
+}
+
+Board::~Board() noexcept
+{
+}
+
+void Board::load(const QByteArray& content, QStringList* errors)
+{
+    QDomDocument doc;
+    doc.implementation().setInvalidDataPolicy(QDomImplementation::ReturnNullNode);
+    QString errMsg;
+    if (!doc.setContent(content, &errMsg)) {
+        throw std::runtime_error(
+            "Error while parsing EAGLE board: " + errMsg.toStdString());
+    }
+    DomElement root(doc.documentElement());
+    DomElement drawing = root.getFirstChild("drawing");
+
+    if (drawing.hasChild("grid")) {
+        mGrid = Grid(drawing.getFirstChild("grid"));
+    }
+
+    DomElement board = drawing.getFirstChild("board");
+    if (board.hasChild("designrules")) {
+        mDesignRules = DesignRules(board.getFirstChild("designrules"), errors);
+    }
+    if (board.hasChild("libraries")) {
+        foreach (const DomElement& child, board.getFirstChild("libraries").getChilds()) {
+            mLibraries.append(Library(child));
+        }
+    }
+    if (board.hasChild("plain")) {
+        foreach (const DomElement& child, board.getFirstChild("plain").getChilds()) {
+            if (child.getTagName() == "wire") {
+                mWires.append(Wire(child));
+            } else if (child.getTagName() == "rectangle") {
+                mRectangles.append(Rectangle(child));
+            } else if (child.getTagName() == "circle") {
+                mCircles.append(Circle(child));
+            } else if (child.getTagName() == "polygon") {
+                mPolygons.append(Polygon(child, errors));
+            } else if (child.getTagName() == "text") {
+                mTexts.append(Text(child, errors));
+            } else if (child.getTagName() == "hole") {
+                mHoles.append(Hole(child));
+            } else if (child.getTagName() == "dimension") {
+                mDimensions.append(Dimension(child));
+            } else if (errors) {
+                errors->append("Unknown board child: " + child.getTagName());
+            }
+        }
+    }
+    if (board.hasChild("elements")) {
+        foreach (const DomElement& child, board.getFirstChild("elements").getChilds()) {
+            mElements.append(Element(child, errors));
+        }
+    }
+    if (board.hasChild("signals")) {
+        foreach (const DomElement& child, board.getFirstChild("signals").getChilds()) {
+            mSignals.append(Signal(child, errors));
+        }
+    }
+}
+
+} // namespace parseagle

--- a/parseagle/board/board.h
+++ b/parseagle/board/board.h
@@ -1,0 +1,65 @@
+#ifndef PARSEAGLE_BOARD_H
+#define PARSEAGLE_BOARD_H
+
+#include <QtCore>
+#include "../common/grid.h"
+#include "../common/wire.h"
+#include "../common/rectangle.h"
+#include "../common/circle.h"
+#include "../common/polygon.h"
+#include "../common/text.h"
+#include "../common/dimension.h"
+#include "../package/hole.h"
+#include "../library.h"
+#include "designrules.h"
+#include "element.h"
+#include "signal.h"
+
+namespace parseagle {
+
+class Board final
+{
+    public:
+
+        // Constructors / Destructor
+        Board() = delete;
+        explicit Board(const QString& filepath, QStringList* errors = nullptr);
+        explicit Board(const QByteArray& content, QStringList* errors = nullptr);
+        ~Board() noexcept;
+
+        // Getters
+        const Grid& getGrid() const noexcept {return mGrid;}
+        const DesignRules& getDesignRules() const noexcept {return mDesignRules;}
+        const QList<Library>& getLibraries() const noexcept {return mLibraries;}
+        const QList<Wire>& getWires() const noexcept {return mWires;}
+        const QList<Rectangle>& getRectangles() const noexcept {return mRectangles;}
+        const QList<Circle>& getCircles() const noexcept {return mCircles;}
+        const QList<Polygon>& getPolygons() const noexcept {return mPolygons;}
+        const QList<Text>& getTexts() const noexcept {return mTexts;}
+        const QList<Hole>& getHoles() const noexcept {return mHoles;}
+        const QList<Dimension>& getDimensions() const noexcept {return mDimensions;}
+        const QList<Element>& getElements() const noexcept {return mElements;}
+        const QList<Signal>& getSignals() const noexcept {return mSignals;}
+
+
+    private:
+        void load(const QByteArray& content, QStringList* errors = nullptr);
+
+
+        Grid mGrid;
+        DesignRules mDesignRules;
+        QList<Library> mLibraries;
+        QList<Wire> mWires;
+        QList<Rectangle> mRectangles;
+        QList<Circle> mCircles;
+        QList<Polygon> mPolygons;
+        QList<Text> mTexts;
+        QList<Hole> mHoles;
+        QList<Dimension> mDimensions;
+        QList<Element> mElements;
+        QList<Signal> mSignals;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_BOARD_H

--- a/parseagle/board/contactref.cpp
+++ b/parseagle/board/contactref.cpp
@@ -1,0 +1,17 @@
+#include <QtCore>
+#include "contactref.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+ContactRef::ContactRef(const DomElement& root)
+{
+    mElement = root.getAttributeAsString("element");
+    mPad = root.getAttributeAsString("pad");
+}
+
+ContactRef::~ContactRef() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/board/contactref.h
+++ b/parseagle/board/contactref.h
@@ -1,0 +1,31 @@
+#ifndef PARSEAGLE_CONTACTREF_H
+#define PARSEAGLE_CONTACTREF_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class ContactRef final
+{
+    public:
+
+        // Constructors / Destructor
+        ContactRef() = delete;
+        explicit ContactRef(const DomElement& root);
+        ~ContactRef() noexcept;
+
+        // Getters
+        const QString& getElement() const noexcept {return mElement;}
+        const QString& getPad() const noexcept {return mPad;}
+
+
+    private:
+        QString mElement;
+        QString mPad;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_CONTACTREF_H

--- a/parseagle/board/designrules.cpp
+++ b/parseagle/board/designrules.cpp
@@ -1,0 +1,35 @@
+#include <QtCore>
+#include "designrules.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+DesignRules::DesignRules(const DomElement& root, QStringList* errors)
+{
+    mName = root.getAttributeAsString("name");
+    foreach (const DomElement& child, root.getChilds()) {
+        if (child.getTagName() == "description") {
+            mDescription = child.getText();
+        } else if (child.getTagName() == "param") {
+            mParams.append(Param(child));
+        } else if (errors) {
+            errors->append("Unknown design rules child: " + child.getTagName());
+        }
+    }
+}
+
+DesignRules::~DesignRules() noexcept
+{
+}
+
+const Param* DesignRules::tryGetParam(const QString& name) const noexcept
+{
+    foreach (const Param& param, mParams) {
+        if (param.getName() == name) {
+            return &param;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace parseagle

--- a/parseagle/board/designrules.h
+++ b/parseagle/board/designrules.h
@@ -1,0 +1,35 @@
+#ifndef PARSEAGLE_DESIGNRULES_H
+#define PARSEAGLE_DESIGNRULES_H
+
+#include <QtCore>
+#include "param.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class DesignRules final
+{
+    public:
+
+        // Constructors / Destructor
+        DesignRules() = default;
+        explicit DesignRules(const DomElement& root, QStringList* errors = nullptr);
+        ~DesignRules() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+        const QString& getDescription() const noexcept {return mDescription;}
+        const QList<Param>& getParams() const noexcept {return mParams;}
+        const Param* tryGetParam(const QString& name) const noexcept;
+
+
+    private:
+        QString mName;
+        QString mDescription;
+        QList<Param> mParams;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_DESIGNRULES_H

--- a/parseagle/board/element.cpp
+++ b/parseagle/board/element.cpp
@@ -1,0 +1,43 @@
+#include <QtCore>
+#include "element.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Element::Element(const DomElement& root, QStringList* errors)
+{
+    mName = root.getAttributeAsString("name");
+    mLibrary = root.getAttributeAsString("library");
+    if (root.hasAttribute("library_urn")) {
+        mLibraryUrn = root.getAttributeAsString("library_urn");
+    }
+    mPackage = root.getAttributeAsString("package");
+    mValue = root.getAttributeAsString("value");
+    mPosition.x = root.getAttributeAsDouble("x");
+    mPosition.y = root.getAttributeAsDouble("y");
+    if (root.hasAttribute("rot")) {
+        mRotation = Rotation(root.getAttributeAsString("rot"));
+    }
+    if (root.hasAttribute("locked")) {
+        mLocked = root.getAttributeAsBool("locked");
+    }
+    if (root.hasAttribute("populate")) {
+        mPopulate = root.getAttributeAsBool("populate");
+    }
+    if (root.hasAttribute("smashed")) {
+        mSmashed = root.getAttributeAsBool("smashed");
+    }
+    foreach (const DomElement& child, root.getChilds()) {
+        if (child.getTagName() == "attribute") {
+            mAttributes.append(Attribute(child, errors));
+        } else  if (errors) {
+            errors->append("Unknown element child: " + child.getTagName());
+        }
+    }
+}
+
+Element::~Element() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/board/element.h
+++ b/parseagle/board/element.h
@@ -1,0 +1,52 @@
+#ifndef PARSEAGLE_ELEMENT_H
+#define PARSEAGLE_ELEMENT_H
+
+#include <QtCore>
+#include "../common/attribute.h"
+#include "../common/point.h"
+#include "../common/rotation.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Element final
+{
+    public:
+
+        // Constructors / Destructor
+        Element() = delete;
+        explicit Element(const DomElement& root, QStringList* errors = nullptr);
+        ~Element() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+        const QString& getLibrary() const noexcept {return mLibrary;}
+        const QString& getLibraryUrn() const noexcept {return mLibraryUrn;}
+        const QString& getPackage() const noexcept {return mPackage;}
+        const QString& getValue() const noexcept {return mValue;}
+        const Point& getPosition() const noexcept {return mPosition;}
+        const Rotation& getRotation() const noexcept {return mRotation;}
+        bool getLocked() const noexcept {return mLocked;}
+        bool getPopulate() const noexcept {return mPopulate;}
+        bool getSmashed() const noexcept {return mSmashed;}
+        const QList<Attribute>& getAttributes() const noexcept {return mAttributes;}
+
+
+    private:
+        QString mName;
+        QString mLibrary;
+        QString mLibraryUrn;
+        QString mPackage;
+        QString mValue;
+        Point mPosition;
+        Rotation mRotation;
+        bool mLocked = false;
+        bool mPopulate = true;
+        bool mSmashed = false;
+        QList<Attribute> mAttributes;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_ELEMENT_H

--- a/parseagle/board/param.cpp
+++ b/parseagle/board/param.cpp
@@ -1,0 +1,48 @@
+#include <QtCore>
+#include "param.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Param::Param(const DomElement& root)
+{
+    mName = root.getAttributeAsString("name");
+    mValue = root.getAttributeAsString("value");
+}
+
+Param::~Param() noexcept
+{
+}
+
+bool Param::tryGetValueAsInt(int& value) const noexcept
+{
+    bool ok = false;
+    value = mValue.toInt(&ok);
+    return ok;
+}
+
+bool Param::tryGetValueAsDouble(double& value) const noexcept
+{
+    bool ok = false;
+    value = mValue.toDouble(&ok);
+    return ok;
+}
+
+bool Param::tryGetValueAsDoubleWithUnit(double& value, QString& unit) const noexcept
+{
+    int unitLength = 0;
+    for (int i = mValue.count()-1; i >= 0; --i) {
+      if (mValue.at(i).isLetter()) {
+        ++unitLength;
+      } else {
+        break;
+      }
+    }
+
+    bool ok = false;
+    value = mValue.left(mValue.length() - unitLength).toDouble(&ok);
+    unit = mValue.right(unitLength);
+    return ok;
+}
+
+} // namespace parseagle

--- a/parseagle/board/param.h
+++ b/parseagle/board/param.h
@@ -1,0 +1,34 @@
+#ifndef PARSEAGLE_PARAM_H
+#define PARSEAGLE_PARAM_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class Param final
+{
+    public:
+
+        // Constructors / Destructor
+        Param() = delete;
+        explicit Param(const DomElement& root);
+        ~Param() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+        const QString& getValue() const noexcept {return mValue;}
+        bool tryGetValueAsInt(int& value) const noexcept;
+        bool tryGetValueAsDouble(double& value) const noexcept;
+        bool tryGetValueAsDoubleWithUnit(double& value, QString& unit) const noexcept;
+
+
+    private:
+        QString mName;
+        QString mValue;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_PARAM_H

--- a/parseagle/board/signal.cpp
+++ b/parseagle/board/signal.cpp
@@ -1,0 +1,32 @@
+#include <QtCore>
+#include "signal.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Signal::Signal(const DomElement& root, QStringList* errors)
+{
+    mName = root.getAttributeAsString("name");
+    if (root.hasAttribute("class")) {
+        mClass = root.getAttributeAsInt("class");
+    }
+    foreach (const DomElement& child, root.getChilds()) {
+        if (child.getTagName() == "contactref") {
+            mContactRefs.append(ContactRef(child));
+        } else if (child.getTagName() == "polygon") {
+            mPolygons.append(Polygon(child, errors));
+        } else if (child.getTagName() == "wire") {
+            mWires.append(Wire(child));
+        } else if (child.getTagName() == "via") {
+            mVias.append(Via(child));
+        } else if (errors) {
+            errors->append("Unknown signal child: " + child.getTagName());
+        }
+    }
+}
+
+Signal::~Signal() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/board/signal.h
+++ b/parseagle/board/signal.h
@@ -1,0 +1,43 @@
+#ifndef PARSEAGLE_SIGNAL_H
+#define PARSEAGLE_SIGNAL_H
+
+#include <QtCore>
+#include "../common/wire.h"
+#include "../common/polygon.h"
+#include "contactref.h"
+#include "via.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Signal final
+{
+    public:
+
+        // Constructors / Destructor
+        Signal() = delete;
+        explicit Signal(const DomElement& root, QStringList* errors = nullptr);
+        ~Signal() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+        int getClass() const noexcept {return mClass;}
+        const QList<ContactRef>& getContactRefs() const noexcept {return mContactRefs;}
+        const QList<Polygon>& getPolygons() const noexcept {return mPolygons;}
+        const QList<Wire>& getWires() const noexcept {return mWires;}
+        const QList<Via>& getVias() const noexcept {return mVias;}
+
+
+    private:
+        QString mName;
+        int mClass = 0;
+        QList<ContactRef> mContactRefs;
+        QList<Polygon> mPolygons;
+        QList<Wire> mWires;
+        QList<Via> mVias;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_SIGNAL_H

--- a/parseagle/board/via.cpp
+++ b/parseagle/board/via.cpp
@@ -1,0 +1,42 @@
+#include <QtCore>
+#include "via.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Via::Via(const DomElement& root, QStringList* errors)
+{
+    mPosition.x = root.getAttributeAsDouble("x");
+    mPosition.y = root.getAttributeAsDouble("y");
+    mExtent = root.getAttributeAsString("extent");
+    mDrill = root.getAttributeAsDouble("drill");
+    if (root.hasAttribute("diameter")) {
+        mDiameter = root.getAttributeAsDouble("diameter");
+    }
+    if (root.hasAttribute("shape")) {
+        mShape = parseViaShape(root.getAttributeAsString("shape"), errors);
+    }
+    if (root.hasAttribute("alwaysstop")) {
+        mAlwaysStop = root.getAttributeAsBool("alwaysstop");
+    }
+}
+
+Via::~Via() noexcept
+{
+}
+
+bool Via::tryGetStartLayer(int& layer) const noexcept
+{
+    bool ok = false;
+    layer = mExtent.section('-', 0, 0).toInt(&ok);
+    return ok;
+}
+
+bool Via::tryGetEndLayer(int& layer) const noexcept
+{
+    bool ok = false;
+    layer = mExtent.section('-', 1, 1).toInt(&ok);
+    return ok;
+}
+
+} // namespace parseagle

--- a/parseagle/board/via.h
+++ b/parseagle/board/via.h
@@ -1,0 +1,43 @@
+#ifndef PARSEAGLE_VIA_H
+#define PARSEAGLE_VIA_H
+
+#include <QtCore>
+#include "../common/enums.h"
+#include "../common/point.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Via final
+{
+    public:
+
+        // Constructors / Destructor
+        Via() = delete;
+        explicit Via(const DomElement& root, QStringList* errors = nullptr);
+        ~Via() noexcept;
+
+        // Getters
+        const Point& getPosition() const noexcept {return mPosition;}
+        const QString& getExtent() const noexcept {return mExtent;}
+        bool tryGetStartLayer(int& layer) const noexcept;
+        bool tryGetEndLayer(int& layer) const noexcept;
+        double getDrill() const noexcept {return mDrill;}
+        double getDiameter() const noexcept {return mDiameter;}
+        ViaShape getShape() const noexcept {return mShape;}
+        bool getAlwaysStop() const noexcept {return mAlwaysStop;}
+
+
+    private:
+        Point mPosition;
+        QString mExtent;
+        double mDrill;
+        double mDiameter = 0;
+        ViaShape mShape = ViaShape::Round;
+        bool mAlwaysStop = false;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_VIA_H

--- a/parseagle/common/attribute.cpp
+++ b/parseagle/common/attribute.cpp
@@ -1,0 +1,49 @@
+#include <QtCore>
+#include "attribute.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Attribute::Attribute(const DomElement& root, QStringList* errors)
+{
+    mName = root.getAttributeAsString("name");
+    if (root.hasAttribute("value")) {
+        mValue = root.getAttributeAsString("value");
+    }
+    if (root.hasAttribute("x")) {
+        mPosition.x = root.getAttributeAsDouble("x");
+    }
+    if (root.hasAttribute("y")) {
+        mPosition.y = root.getAttributeAsDouble("y");
+    }
+    if (root.hasAttribute("size")) {
+        mSize = root.getAttributeAsDouble("size");
+    }
+    if (root.hasAttribute("layer")) {
+        mLayer = root.getAttributeAsInt("layer");
+    }
+    if (root.hasAttribute("font")) {
+        mFont = parseFont(root.getAttributeAsString("font"), errors);
+    }
+    if (root.hasAttribute("ratio")) {
+        mRatio = root.getAttributeAsInt("ratio");
+    }
+    if (root.hasAttribute("rot")) {
+        mRotation = Rotation(root.getAttributeAsString("rot"));
+    }
+    if (root.hasAttribute("display")) {
+        mDisplay = parseAttributeDisplay(root.getAttributeAsString("display"), errors);
+    }
+    if (root.hasAttribute("constant")) {
+        mConstant = root.getAttributeAsBool("constant");
+    }
+    if (root.hasAttribute("align")) {
+        mAlignment = parseAlignment(root.getAttributeAsString("align"), errors);
+    }
+}
+
+Attribute::~Attribute() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/common/attribute.h
+++ b/parseagle/common/attribute.h
@@ -1,0 +1,52 @@
+#ifndef PARSEAGLE_ATTRIBUTE_H
+#define PARSEAGLE_ATTRIBUTE_H
+
+#include <QtCore>
+#include "../common/enums.h"
+#include "../common/point.h"
+#include "../common/rotation.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Attribute final
+{
+    public:
+
+        // Constructors / Destructor
+        Attribute() = delete;
+        explicit Attribute(const DomElement& root, QStringList* errors = nullptr);
+        ~Attribute() noexcept;
+
+        // Getters
+        QString getName() const noexcept {return mName;}
+        QString getValue() const noexcept {return mValue;}
+        const Point& getPosition() const noexcept {return mPosition;}
+        double getSize() const noexcept {return mSize;}
+        int getLayer() const noexcept {return mLayer;}
+        Font getFont() const noexcept {return mFont;}
+        int getRatio() const noexcept {return mRatio;}
+        const Rotation& getRotation() const noexcept {return mRotation;}
+        AttributeDisplay getDisplay() const noexcept {return mDisplay;}
+        bool getConstant() const noexcept {return mConstant;}
+        Alignment getAlignment() const noexcept {return mAlignment;}
+
+
+    private:
+        QString mName;
+        QString mValue;
+        Point mPosition;
+        double mSize = 0;
+        int mLayer = 0;
+        Font mFont = Font::Unknown;
+        int mRatio = 0;
+        Rotation mRotation;
+        AttributeDisplay mDisplay = AttributeDisplay::Value;
+        bool mConstant = false;
+        Alignment mAlignment = Alignment::BottomLeft;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_ATTRIBUTE_H

--- a/parseagle/common/dimension.cpp
+++ b/parseagle/common/dimension.cpp
@@ -1,0 +1,16 @@
+#include <QtCore>
+#include "dimension.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Dimension::Dimension(const DomElement& root)
+{
+    Q_UNUSED(root);
+}
+
+Dimension::~Dimension() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/common/dimension.h
+++ b/parseagle/common/dimension.h
@@ -1,0 +1,26 @@
+#ifndef PARSEAGLE_DIMENSION_H
+#define PARSEAGLE_DIMENSION_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class Dimension final
+{
+    public:
+
+        // Constructors / Destructor
+        Dimension() = delete;
+        explicit Dimension(const DomElement& root);
+        ~Dimension() noexcept;
+
+
+    private:
+        // Not implemented yet.
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_DIMENSION_H

--- a/parseagle/common/domelement.cpp
+++ b/parseagle/common/domelement.cpp
@@ -35,6 +35,17 @@ QString DomElement::getAttributeAsString(const QString& name) const
     }
 }
 
+bool DomElement::getAttributeAsBool(const QString& name) const {
+  const QString value = getAttributeAsString(name);
+  if (value == "yes") {
+    return true;
+  } else if (value == "no") {
+    return false;
+  } else {
+    throw std::runtime_error("Invalid bool in attribute " + name.toStdString());
+  }
+}
+
 int DomElement::getAttributeAsInt(const QString& name) const
 {
     bool ok = false;

--- a/parseagle/common/domelement.h
+++ b/parseagle/common/domelement.h
@@ -21,6 +21,7 @@ class DomElement final
         const QString& getText() const noexcept {return mText;}
         bool hasAttribute(const QString& name) const noexcept {return mAttributes.contains(name);}
         QString getAttributeAsString(const QString& name) const;
+        bool getAttributeAsBool(const QString& name) const;
         int getAttributeAsInt(const QString& name) const;
         double getAttributeAsDouble(const QString& name) const;
         bool hasChild(const QString& tagName = QString()) const noexcept;

--- a/parseagle/common/enums.h
+++ b/parseagle/common/enums.h
@@ -45,6 +45,53 @@ inline Alignment parseAlignment(const QString& s, QStringList* errors = nullptr)
     return Alignment::Unknown;
 }
 
+enum class AttributeDisplay
+{
+    Unknown,  // Failed to parse XML attribute.
+    Off,
+    Value,
+    Name,
+    Both,
+};
+
+inline AttributeDisplay parseAttributeDisplay(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "off") {
+        return AttributeDisplay::Off;
+    } else if (s == "value") {
+        return AttributeDisplay::Value;
+    } else if (s == "name") {
+        return AttributeDisplay::Name;
+    } else if (s == "both") {
+        return AttributeDisplay::Both;
+    } else if (errors) {
+        errors->append("Unknown attribute display: " + s);
+    }
+    return AttributeDisplay::Unknown;
+}
+
+enum class Font
+{
+    Unknown,  // Failed to parse XML attribute.
+    Fixed,
+    Proportional,
+    Vector,
+};
+
+inline Font parseFont(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "fixed") {
+        return Font::Fixed;
+    } else if (s == "proportional") {
+        return Font::Proportional;
+    } else if (s == "vector") {
+        return Font::Vector;
+    } else if (errors) {
+        errors->append("Unknown font: " + s);
+    }
+    return Font::Unknown;
+}
+
 enum class GateAddLevel
 {
     Unknown,  // Failed to parse XML attribute.
@@ -71,6 +118,50 @@ inline GateAddLevel parseGateAddLevel(const QString& s, QStringList* errors = nu
         errors->append("Unknown gate add level: " + s);
     }
     return GateAddLevel::Unknown;
+}
+
+enum class GridStyle
+{
+    Unknown,  // Failed to parse XML attribute.
+    Lines,
+    Dots,
+};
+
+inline GridStyle parseGridStyle(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "lines") {
+        return GridStyle::Lines;
+    } else if (s == "dots") {
+        return GridStyle::Dots;
+    } else if (errors) {
+        errors->append("Unknown grid style: " + s);
+    }
+    return GridStyle::Unknown;
+}
+
+enum class GridUnit
+{
+    Unknown,  // Failed to parse XML attribute.
+    Micrometers,
+    Millimeters,
+    Mils,
+    Inches,
+};
+
+inline GridUnit parseGridUnit(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "mic") {
+        return GridUnit::Micrometers;
+    } else if (s == "mm") {
+        return GridUnit::Millimeters;
+    } else if (s == "mil") {
+        return GridUnit::Mils;
+    } else if (s == "inch") {
+        return GridUnit::Inches;
+    } else if (errors) {
+        errors->append("Unknown grid unit: " + s);
+    }
+    return GridUnit::Unknown;
 }
 
 enum class PadShape
@@ -101,6 +192,71 @@ inline PadShape parsePadShape(const QString& s, QStringList* errors = nullptr)
     return PadShape::Unknown;
 }
 
+enum class PinDirection
+{
+    Unknown,  // Failed to parse XML attribute.
+    NotConnected,
+    Input,
+    Output,
+    IO,
+    OpenCollector,
+    Power,
+    Passive,
+    HighZ,
+    Supply,
+};
+
+inline PinDirection parsePinDirection(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "nc") {
+        return PinDirection::NotConnected;
+    } else if (s == "in") {
+        return PinDirection::Input;
+    } else if (s == "out") {
+        return PinDirection::Output;
+    } else if (s == "io") {
+        return PinDirection::IO;
+    } else if (s == "oc") {
+        return PinDirection::OpenCollector;
+    } else if (s == "pwr") {
+        return PinDirection::Power;
+    } else if (s == "pas") {
+        return PinDirection::Passive;
+    } else if (s == "hiz") {
+        return PinDirection::HighZ;
+    } else if (s == "sup") {
+        return PinDirection::Supply;
+    } else if (errors) {
+        errors->append("Unknown pin direction: " + s);
+    }
+    return PinDirection::Unknown;
+}
+
+enum class PinFunction
+{
+    Unknown,  // Failed to parse XML attribute.
+    None,
+    Dot,
+    Clock,
+    DotClock,
+};
+
+inline PinFunction parsePinFunction(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "none") {
+        return PinFunction::None;
+    } else if (s == "dot") {
+        return PinFunction::Dot;
+    } else if (s == "clk") {
+        return PinFunction::Clock;
+    } else if (s == "dotclk") {
+        return PinFunction::DotClock;
+    } else if (errors) {
+        errors->append("Unknown pin function: " + s);
+    }
+    return PinFunction::Unknown;
+}
+
 enum class PinLength
 {
     Unknown,  // Failed to parse XML attribute.
@@ -124,6 +280,75 @@ inline PinLength parsePinLength(const QString& s, QStringList* errors = nullptr)
         errors->append("Unknown pin length: " + s);
     }
     return PinLength::Unknown;
+}
+
+enum class PinVisibility
+{
+    Unknown,  // Failed to parse XML attribute.
+    Off,
+    Pad,
+    Pin,
+    Both,
+};
+
+inline PinVisibility parsePinVisibility(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "off") {
+        return PinVisibility::Off;
+    } else if (s == "pad") {
+        return PinVisibility::Pad;
+    } else if (s == "pin") {
+        return PinVisibility::Pin;
+    } else if (s == "both") {
+        return PinVisibility::Both;
+    } else if (errors) {
+        errors->append("Unknown pin visibility: " + s);
+    }
+    return PinVisibility::Unknown;
+}
+
+enum class PolygonPour
+{
+    Unknown,  // Failed to parse XML attribute.
+    Solid,
+    Hatch,
+    Cutout,
+};
+
+inline PolygonPour parsePolygonPour(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "solid") {
+        return PolygonPour::Solid;
+    } else if (s == "hatch") {
+        return PolygonPour::Hatch;
+    } else if (s == "cutout") {
+        return PolygonPour::Cutout;
+    } else if (errors) {
+        errors->append("Unknown polygon pour: " + s);
+    }
+    return PolygonPour::Unknown;
+}
+
+enum class ViaShape
+{
+    Unknown,  // Failed to parse XML attribute.
+    Square,
+    Round,
+    Octagon,
+};
+
+inline ViaShape parseViaShape(const QString& s, QStringList* errors = nullptr)
+{
+    if (s == "square") {
+        return ViaShape::Square;
+    } else if (s == "round") {
+        return ViaShape::Round;
+    } else if (s == "octagon") {
+        return ViaShape::Octagon;
+    } else if (errors) {
+        errors->append("Unknown via shape: " + s);
+    }
+    return ViaShape::Unknown;
 }
 
 } // namespace parseagle

--- a/parseagle/common/frame.cpp
+++ b/parseagle/common/frame.cpp
@@ -1,0 +1,22 @@
+#include <QtCore>
+#include "frame.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Frame::Frame(const DomElement& root)
+{
+    mLayer = root.getAttributeAsInt("layer");
+    mP1.x = root.getAttributeAsDouble("x1");
+    mP1.y = root.getAttributeAsDouble("y1");
+    mP2.x = root.getAttributeAsDouble("x2");
+    mP2.y = root.getAttributeAsDouble("y2");
+    mColumns = root.getAttributeAsInt("columns");
+    mRows = root.getAttributeAsInt("rows");
+}
+
+Frame::~Frame() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/common/frame.h
+++ b/parseagle/common/frame.h
@@ -1,0 +1,39 @@
+#ifndef PARSEAGLE_FRAME_H
+#define PARSEAGLE_FRAME_H
+
+#include <QtCore>
+#include "../common/point.h"
+#include "../common/rotation.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Frame final
+{
+    public:
+
+        // Constructors / Destructor
+        Frame() = delete;
+        explicit Frame(const DomElement& root);
+        ~Frame() noexcept;
+
+        // Getters
+        int getLayer() const noexcept {return mLayer;}
+        const Point& getP1() const noexcept {return mP1;}
+        const Point& getP2() const noexcept {return mP2;}
+        int getColumns() const noexcept {return mColumns;}
+        int getRows() const noexcept {return mRows;}
+
+
+    private:
+        int mLayer;
+        Point mP1;
+        Point mP2;
+        int mColumns;
+        int mRows;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_FRAME_H

--- a/parseagle/common/grid.cpp
+++ b/parseagle/common/grid.cpp
@@ -1,0 +1,43 @@
+#include <QtCore>
+#include "grid.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+
+Grid::Grid(const DomElement& root, QStringList* errors)
+{
+    if (root.hasAttribute("distance")) {
+        mDistance = root.getAttributeAsDouble("distance");
+    }
+    if (root.hasAttribute("unitdist")) {
+        mUnitDistance = parseGridUnit(root.getAttributeAsString("unitdist"), errors);
+    }
+    if (root.hasAttribute("unit")) {
+        mUnit = parseGridUnit(root.getAttributeAsString("unit"), errors);
+    }
+    if (root.hasAttribute("style")) {
+        mStyle = parseGridStyle(root.getAttributeAsString("style"), errors);
+    }
+    if (root.hasAttribute("multiple")) {
+        mMultiple = root.getAttributeAsInt("multiple");
+    }
+    if (root.hasAttribute("display")) {
+        mDisplay = root.getAttributeAsBool("display");
+    }
+    if (root.hasAttribute("altdistance")) {
+        mAltDistance = root.getAttributeAsDouble("altdistance");
+    }
+    if (root.hasAttribute("altunitdist")) {
+        mAltUnitDistance = parseGridUnit(root.getAttributeAsString("altunitdist"), errors);
+    }
+    if (root.hasAttribute("altunit")) {
+        mAltUnit = parseGridUnit(root.getAttributeAsString("altunit"), errors);
+    }
+}
+
+Grid::~Grid() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/common/grid.h
+++ b/parseagle/common/grid.h
@@ -1,0 +1,46 @@
+#ifndef PARSEAGLE_GRID_H
+#define PARSEAGLE_GRID_H
+
+#include <QtCore>
+#include "enums.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Grid final
+{
+    public:
+
+        // Constructors / Destructor
+        Grid() noexcept = default;
+        explicit Grid(const DomElement& root, QStringList* errors = nullptr);
+        ~Grid() noexcept;
+
+        // Getters
+        double getDistance() const noexcept {return mDistance;}
+        GridUnit getUnitDistance() const noexcept {return mUnitDistance;}
+        GridUnit getUnit() const noexcept {return mUnit;}
+        GridStyle getStyle() const noexcept {return mStyle;}
+        int getMultiple() const noexcept {return mMultiple;}
+        bool getDisplay() const noexcept {return mDisplay;}
+        double getAltDistance() const noexcept {return mAltDistance;}
+        GridUnit getAltUnitDistance() const noexcept {return mAltUnitDistance;}
+        GridUnit getAltUnit() const noexcept {return mAltUnit;}
+
+
+    private:
+        double mDistance = 0;
+        GridUnit mUnitDistance = GridUnit::Unknown;
+        GridUnit mUnit = GridUnit::Unknown;
+        GridStyle mStyle = GridStyle::Lines;
+        int mMultiple = 1;
+        bool mDisplay = false;
+        double mAltDistance = 0;
+        GridUnit mAltUnitDistance = GridUnit::Unknown;
+        GridUnit mAltUnit = GridUnit::Unknown;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_GRID_H

--- a/parseagle/common/polygon.cpp
+++ b/parseagle/common/polygon.cpp
@@ -4,10 +4,28 @@
 
 namespace parseagle {
 
-Polygon::Polygon(const DomElement& root)
+Polygon::Polygon(const DomElement& root, QStringList* errors)
 {
     mLayer = root.getAttributeAsInt("layer");
     mWidth = root.getAttributeAsDouble("width");
+    if (root.hasAttribute("spacing")) {
+        mSpacing = root.getAttributeAsDouble("spacing");
+    }
+    if (root.hasAttribute("pour")) {
+        mPour = parsePolygonPour(root.getAttributeAsString("pour"), errors);
+    }
+    if (root.hasAttribute("isolate")) {
+        mIsolate = root.getAttributeAsDouble("isolate");
+    }
+    if (root.hasAttribute("orphans")) {
+        mOrphans = root.getAttributeAsBool("orphans");
+    }
+    if (root.hasAttribute("thermals")) {
+        mThermals = root.getAttributeAsBool("thermals");
+    }
+    if (root.hasAttribute("rank")) {
+        mRank = root.getAttributeAsInt("rank");
+    }
     foreach (const DomElement& child, root.getChilds()) {
         mVertices.append(Vertex(child));
     }

--- a/parseagle/common/polygon.h
+++ b/parseagle/common/polygon.h
@@ -2,6 +2,7 @@
 #define PARSEAGLE_POLYGON_H
 
 #include <QtCore>
+#include "enums.h"
 #include "vertex.h"
 
 namespace parseagle {
@@ -14,18 +15,30 @@ class Polygon final
 
         // Constructors / Destructor
         Polygon() = delete;
-        explicit Polygon(const DomElement& root);
+        explicit Polygon(const DomElement& root, QStringList* errors = nullptr);
         ~Polygon() noexcept;
 
         // Getters
         int getLayer() const noexcept {return mLayer;}
         double getWidth() const noexcept {return mWidth;}
+        double getSpacing() const noexcept {return mSpacing;}
+        PolygonPour getPour() const noexcept {return mPour;}
+        double getIsolate() const noexcept {return mIsolate;}
+        bool getOrphans() const noexcept {return mOrphans;}
+        bool getThermals() const noexcept {return mThermals;}
+        int getRank() const noexcept {return mRank;}
         const QList<Vertex>& getVertices() const noexcept {return mVertices;}
 
 
     private:
         int mLayer;
         double mWidth;
+        double mSpacing = 0;
+        PolygonPour mPour = PolygonPour::Solid;
+        double mIsolate = 0;
+        bool mOrphans = false;
+        bool mThermals = true;
+        int mRank = 0;
         QList<Vertex> mVertices;
 };
 

--- a/parseagle/common/text.cpp
+++ b/parseagle/common/text.cpp
@@ -7,7 +7,13 @@ namespace parseagle {
 Text::Text(const DomElement& root, QStringList* errors)
 {
     mLayer = root.getAttributeAsInt("layer");
+    if (root.hasAttribute("font")) {
+        mFont = parseFont(root.getAttributeAsString("font"), errors);
+    }
     mSize = root.getAttributeAsDouble("size");
+    if (root.hasAttribute("ratio")) {
+        mRatio = root.getAttributeAsInt("ratio");
+    }
     mPosition.x = root.getAttributeAsDouble("x");
     mPosition.y = root.getAttributeAsDouble("y");
     if (root.hasAttribute("rot")) {

--- a/parseagle/common/text.h
+++ b/parseagle/common/text.h
@@ -24,7 +24,9 @@ class Text final
 
         // Getters
         int getLayer() const noexcept {return mLayer;}
+        Font getFont() const noexcept {return mFont;}
         double getSize() const noexcept {return mSize;}
+        int getRatio() const noexcept {return mRatio;}
         const Point& getPosition() const noexcept {return mPosition;}
         const Rotation& getRotation() const noexcept {return mRotation;}
         Alignment getAlignment() const noexcept {return mAlignment;}
@@ -33,7 +35,9 @@ class Text final
 
     private:
         int mLayer;
+        Font mFont = Font::Proportional;
         double mSize;
+        int mRatio = 8;
         Point mPosition;
         Rotation mRotation;
         Alignment mAlignment = Alignment::BottomLeft;

--- a/parseagle/deviceset/deviceset.cpp
+++ b/parseagle/deviceset/deviceset.cpp
@@ -10,6 +10,9 @@ DeviceSet::DeviceSet(const DomElement& root, QStringList* errors)
     if (root.hasAttribute("prefix")) {
         mPrefix = root.getAttributeAsString("prefix");
     }
+    if (root.hasAttribute("uservalue")) {
+        mUserValue = root.getAttributeAsBool("uservalue");
+    }
     if (root.hasChild("description")) {
         mDescription = root.getFirstChild("description").getText();
     }

--- a/parseagle/deviceset/deviceset.h
+++ b/parseagle/deviceset/deviceset.h
@@ -22,6 +22,7 @@ class DeviceSet final
         QString getName() const noexcept {return mName;}
         QString getDescription() const noexcept {return mDescription;}
         QString getPrefix() const noexcept {return mPrefix;}
+        bool getUserValue() const noexcept {return mUserValue;}
         const QList<Gate>& getGates() const noexcept {return mGates;}
         const QList<Device>& getDevices() const noexcept {return mDevices;}
 
@@ -30,6 +31,7 @@ class DeviceSet final
         QString mName;
         QString mDescription;
         QString mPrefix;
+        bool mUserValue = false;
         QList<Gate> mGates;
         QList<Device> mDevices;
 };

--- a/parseagle/library.cpp
+++ b/parseagle/library.cpp
@@ -22,11 +22,17 @@ Library::Library(const QByteArray& content, QStringList* errors)
     load(content, errors);
 }
 
+Library::Library(const DomElement& root, QStringList* errors)
+{
+  load(root, errors);
+}
+
 Library::~Library() noexcept
 {
 }
 
-void Library::load(const QByteArray& content, QStringList* errors) {
+void Library::load(const QByteArray& content, QStringList* errors)
+{
     QDomDocument doc;
     doc.implementation().setInvalidDataPolicy(QDomImplementation::ReturnNullNode);
     QString errMsg;
@@ -37,13 +43,22 @@ void Library::load(const QByteArray& content, QStringList* errors) {
     DomElement root(doc.documentElement());
     DomElement drawing = root.getFirstChild("drawing");
     DomElement library = drawing.getFirstChild("library");
+    load(library, errors);
+}
 
-    if (library.hasChild("description")) {
-        mDescription = library.getFirstChild("description").getText();
+void Library::load(const DomElement& root, QStringList* errors)
+{
+    if (root.hasAttribute("name")) {
+        mEmbeddedName = root.getAttributeAsString("name");
     }
-
-    if (library.hasChild("symbols")) {
-        foreach (const DomElement& child, library.getFirstChild("symbols").getChilds()) {
+    if (root.hasAttribute("urn")) {
+        mEmbeddedUrn = root.getAttributeAsString("urn");
+    }
+    if (root.hasChild("description")) {
+        mDescription = root.getFirstChild("description").getText();
+    }
+    if (root.hasChild("symbols")) {
+        foreach (const DomElement& child, root.getFirstChild("symbols").getChilds()) {
             try {
                 mSymbols.append(Symbol(child, errors));
             } catch (const std::exception& e) {
@@ -53,8 +68,8 @@ void Library::load(const QByteArray& content, QStringList* errors) {
             }
         }
     }
-    if (library.hasChild("packages")) {
-        foreach (const DomElement& child, library.getFirstChild("packages").getChilds()) {
+    if (root.hasChild("packages")) {
+        foreach (const DomElement& child, root.getFirstChild("packages").getChilds()) {
             try {
                 mPackages.append(Package(child, errors));
             } catch (const std::exception& e) {
@@ -64,8 +79,8 @@ void Library::load(const QByteArray& content, QStringList* errors) {
             }
         }
     }
-    if (library.hasChild("devicesets")) {
-        foreach (const DomElement& child, library.getFirstChild("devicesets").getChilds()) {
+    if (root.hasChild("devicesets")) {
+        foreach (const DomElement& child, root.getFirstChild("devicesets").getChilds()) {
             try {
                 mDeviceSets.append(DeviceSet(child, errors));
             } catch (const std::exception& e) {

--- a/parseagle/library.h
+++ b/parseagle/library.h
@@ -16,10 +16,13 @@ class Library final
         Library() = delete;
         explicit Library(const QString& filepath, QStringList* errors = nullptr);
         explicit Library(const QByteArray& content, QStringList* errors = nullptr);
+        explicit Library(const DomElement& root, QStringList* errors = nullptr);
         ~Library() noexcept;
 
         // Getters
-        QString getDescription() const noexcept {return mDescription;}
+        const QString& getEmbeddedName() const noexcept {return mEmbeddedName;}
+        const QString& getEmbeddedUrn() const noexcept {return mEmbeddedUrn;}
+        const QString& getDescription() const noexcept {return mDescription;}
         const QList<Symbol>& getSymbols() const noexcept {return mSymbols;}
         const QList<Package>& getPackages() const noexcept {return mPackages;}
         const QList<DeviceSet>& getDeviceSets() const noexcept {return mDeviceSets;}
@@ -27,8 +30,11 @@ class Library final
 
     private:
         void load(const QByteArray& content, QStringList* errors = nullptr);
+        void load(const DomElement& root, QStringList* errors = nullptr);
 
 
+        QString mEmbeddedName; // Only for embedded libraries.
+        QString mEmbeddedUrn; // Only for embedded libraries.
         QString mDescription;
         QList<Symbol> mSymbols;
         QList<Package> mPackages;

--- a/parseagle/package/package.cpp
+++ b/parseagle/package/package.cpp
@@ -17,7 +17,7 @@ Package::Package(const DomElement& root, QStringList* errors)
         } else if (child.getTagName() == "circle") {
             mCircles.append(Circle(child));
         } else if (child.getTagName() == "polygon") {
-            mPolygons.append(Polygon(child));
+            mPolygons.append(Polygon(child, errors));
         } else if (child.getTagName() == "text") {
             mTexts.append(Text(child, errors));
         } else if (child.getTagName() == "hole") {
@@ -26,6 +26,8 @@ Package::Package(const DomElement& root, QStringList* errors)
             mThtPads.append(ThtPad(child, errors));
         } else if (child.getTagName() == "smd") {
             mSmtPads.append(SmtPad(child));
+        } else if (child.getTagName() == "dimension") {
+            mDimensions.append(Dimension(child));
         } else if (errors) {
             errors->append("Unknown package child: " + child.getTagName());
         }

--- a/parseagle/package/package.h
+++ b/parseagle/package/package.h
@@ -7,6 +7,7 @@
 #include "../common/circle.h"
 #include "../common/polygon.h"
 #include "../common/text.h"
+#include "../common/dimension.h"
 #include "hole.h"
 #include "thtpad.h"
 #include "smtpad.h"
@@ -35,6 +36,7 @@ class Package final
         const QList<Hole>& getHoles() const noexcept {return mHoles;}
         const QList<ThtPad>& getThtPads() const noexcept {return mThtPads;}
         const QList<SmtPad>& getSmtPads() const noexcept {return mSmtPads;}
+        const QList<Dimension>& getDimensions() const noexcept {return mDimensions;}
 
 
     private:
@@ -48,6 +50,7 @@ class Package final
         QList<Hole> mHoles;
         QList<ThtPad> mThtPads;
         QList<SmtPad> mSmtPads;
+        QList<Dimension> mDimensions;
 };
 
 } // namespace parseagle

--- a/parseagle/package/smtpad.cpp
+++ b/parseagle/package/smtpad.cpp
@@ -15,6 +15,15 @@ SmtPad::SmtPad(const DomElement& root)
     }
     mWidth = root.getAttributeAsDouble("dx");
     mHeight = root.getAttributeAsDouble("dy");
+    if (root.hasAttribute("roundness")) {
+        mRoundness = root.getAttributeAsInt("roundness");
+    }
+    if (root.hasAttribute("stop")) {
+        mStop = root.getAttributeAsBool("stop");
+    }
+    if (root.hasAttribute("cream")) {
+        mCream = root.getAttributeAsBool("cream");
+    }
 }
 
 SmtPad::~SmtPad() noexcept

--- a/parseagle/package/smtpad.h
+++ b/parseagle/package/smtpad.h
@@ -25,6 +25,9 @@ class SmtPad final
         const Rotation& getRotation() const noexcept {return mRotation;}
         double getWidth() const noexcept {return mWidth;}
         double getHeight() const noexcept {return mHeight;}
+        int getRoundness() const noexcept {return mRoundness;}
+        bool getStop() const noexcept {return mStop;}
+        bool getCream() const noexcept {return mCream;}
 
 
     private:
@@ -34,6 +37,9 @@ class SmtPad final
         Rotation mRotation;
         double mWidth;
         double mHeight;
+        int mRoundness = 0;
+        bool mStop = true;
+        bool mCream = true;
 };
 
 } // namespace parseagle

--- a/parseagle/package/thtpad.cpp
+++ b/parseagle/package/thtpad.cpp
@@ -19,6 +19,9 @@ ThtPad::ThtPad(const DomElement& root, QStringList* errors)
     if (root.hasAttribute("rot")) {
         mRotation = Rotation(root.getAttributeAsString("rot"));
     }
+    if (root.hasAttribute("stop")) {
+        mStop = root.getAttributeAsBool("stop");
+    }
 }
 
 ThtPad::~ThtPad() noexcept

--- a/parseagle/package/thtpad.h
+++ b/parseagle/package/thtpad.h
@@ -29,6 +29,7 @@ class ThtPad final
         double getOuterDiameter() const noexcept {return mOuterDiameter;}
         PadShape getShape() const noexcept {return mShape;}
         const Rotation& getRotation() const noexcept {return mRotation;}
+        bool getStop() const noexcept {return mStop;}
 
 
     private:
@@ -38,6 +39,7 @@ class ThtPad final
         double mOuterDiameter = 0;
         PadShape mShape = PadShape::Round;
         Rotation mRotation;
+        bool mStop = true;
 };
 
 } // namespace parseagle

--- a/parseagle/schematic/bus.cpp
+++ b/parseagle/schematic/bus.cpp
@@ -1,0 +1,16 @@
+#include <QtCore>
+#include "bus.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Bus::Bus(const DomElement& root)
+{
+    mName = root.getAttributeAsString("name");
+}
+
+Bus::~Bus() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/bus.h
+++ b/parseagle/schematic/bus.h
@@ -1,0 +1,29 @@
+#ifndef PARSEAGLE_BUS_H
+#define PARSEAGLE_BUS_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class Bus final
+{
+    public:
+
+        // Constructors / Destructor
+        Bus() = delete;
+        explicit Bus(const DomElement& root);
+        ~Bus() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+
+
+    private:
+        QString mName;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_BUS_H

--- a/parseagle/schematic/instance.cpp
+++ b/parseagle/schematic/instance.cpp
@@ -1,0 +1,32 @@
+#include <QtCore>
+#include "instance.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Instance::Instance(const DomElement& root, QStringList* errors)
+{
+    mPart = root.getAttributeAsString("part");
+    mGate = root.getAttributeAsString("gate");
+    mPosition.x = root.getAttributeAsDouble("x");
+    mPosition.y = root.getAttributeAsDouble("y");
+    if (root.hasAttribute("rot")) {
+        mRotation = Rotation(root.getAttributeAsString("rot"));
+    }
+    if (root.hasAttribute("smashed")) {
+        mSmashed = root.getAttributeAsBool("smashed");
+    }
+    foreach (const DomElement& child, root.getChilds()) {
+        if (child.getTagName() == "attribute") {
+            mAttributes.append(Attribute(child, errors));
+        } else  if (errors) {
+            errors->append("Unknown instance child: " + child.getTagName());
+        }
+    }
+}
+
+Instance::~Instance() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/instance.h
+++ b/parseagle/schematic/instance.h
@@ -1,0 +1,42 @@
+#ifndef PARSEAGLE_INSTANCE_H
+#define PARSEAGLE_INSTANCE_H
+
+#include <QtCore>
+#include "../common/attribute.h"
+#include "../common/point.h"
+#include "../common/rotation.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Instance final
+{
+    public:
+
+        // Constructors / Destructor
+        Instance() = delete;
+        explicit Instance(const DomElement& root, QStringList* errors = nullptr);
+        ~Instance() noexcept;
+
+        // Getters
+        const QString& getPart() const noexcept {return mPart;}
+        const QString& getGate() const noexcept {return mGate;}
+        const Point& getPosition() const noexcept {return mPosition;}
+        const Rotation& getRotation() const noexcept {return mRotation;}
+        bool getSmashed() const noexcept {return mSmashed;}
+        const QList<Attribute>& getAttributes() const noexcept {return mAttributes;}
+
+
+    private:
+        QString mPart;
+        QString mGate;
+        Point mPosition;
+        Rotation mRotation;
+        bool mSmashed = false;
+        QList<Attribute> mAttributes;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_INSTANCE_H

--- a/parseagle/schematic/label.cpp
+++ b/parseagle/schematic/label.cpp
@@ -1,0 +1,31 @@
+#include <QtCore>
+#include "label.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Label::Label(const DomElement& root, QStringList* errors)
+{
+    mPosition.x = root.getAttributeAsDouble("x");
+    mPosition.y = root.getAttributeAsDouble("y");
+    mSize = root.getAttributeAsDouble("size");
+    mLayer = root.getAttributeAsInt("layer");
+    if (root.hasAttribute("ratio")) {
+        mRatio = root.getAttributeAsInt("ratio");
+    }
+    if (root.hasAttribute("rot")) {
+        mRotation = Rotation(root.getAttributeAsString("rot"));
+    }
+    if (root.hasAttribute("align")) {
+        mAlignment = parseAlignment(root.getAttributeAsString("align"), errors);
+    }
+    if (root.hasAttribute("xref")) {
+        mXref = root.getAttributeAsBool("xref");
+    }
+}
+
+Label::~Label() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/label.h
+++ b/parseagle/schematic/label.h
@@ -1,0 +1,44 @@
+#ifndef PARSEAGLE_LABEL_H
+#define PARSEAGLE_LABEL_H
+
+#include <QtCore>
+#include "../common/enums.h"
+#include "../common/point.h"
+#include "../common/rotation.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Label final
+{
+    public:
+
+        // Constructors / Destructor
+        Label() = delete;
+        explicit Label(const DomElement& root, QStringList* errors = nullptr);
+        ~Label() noexcept;
+
+        // Getters
+        const Point& getPosition() const noexcept {return mPosition;}
+        double getSize() const noexcept {return mSize;}
+        int getLayer() const noexcept {return mLayer;}
+        int getRatio() const noexcept {return mRatio;}
+        const Rotation& getRotation() const noexcept {return mRotation;}
+        Alignment getAlignment() const noexcept {return mAlignment;}
+        bool getXref() const noexcept {return mXref;}
+
+
+    private:
+        Point mPosition;
+        double mSize;
+        int mLayer;
+        int mRatio = 8;
+        Rotation mRotation;
+        Alignment mAlignment = Alignment::BottomLeft;
+        bool mXref = false;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_LABEL_H

--- a/parseagle/schematic/module.cpp
+++ b/parseagle/schematic/module.cpp
@@ -1,0 +1,16 @@
+#include <QtCore>
+#include "module.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Module::Module(const DomElement& root)
+{
+    mName = root.getAttributeAsString("name");
+}
+
+Module::~Module() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/module.h
+++ b/parseagle/schematic/module.h
@@ -1,0 +1,30 @@
+#ifndef PARSEAGLE_MODULE_H
+#define PARSEAGLE_MODULE_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class Module final
+{
+    public:
+
+        // Constructors / Destructor
+        Module() = delete;
+        explicit Module(const DomElement& root);
+        ~Module() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+
+
+    private:
+        QString mName;
+        // Other attributes not implemented yet.
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_MODULE_H

--- a/parseagle/schematic/net.cpp
+++ b/parseagle/schematic/net.cpp
@@ -1,0 +1,26 @@
+#include <QtCore>
+#include "net.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Net::Net(const DomElement& root, QStringList* errors)
+{
+    mName = root.getAttributeAsString("name");
+    if (root.hasAttribute("class")) {
+        mClass = root.getAttributeAsInt("class");
+    }
+    foreach (const DomElement& child, root.getChilds()) {
+        if (child.getTagName() == "segment") {
+            mSegments.append(Segment(child, errors));
+        } else  if (errors) {
+            errors->append("Unknown net child: " + child.getTagName());
+      }
+    }
+}
+
+Net::~Net() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/net.h
+++ b/parseagle/schematic/net.h
@@ -1,0 +1,34 @@
+#ifndef PARSEAGLE_NET_H
+#define PARSEAGLE_NET_H
+
+#include <QtCore>
+#include "segment.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Net final
+{
+    public:
+
+        // Constructors / Destructor
+        Net() = delete;
+        explicit Net(const DomElement& root, QStringList* errors = nullptr);
+        ~Net() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+        int getClass() const noexcept {return mClass;}
+        const QList<Segment>& getSegments() const noexcept {return mSegments;}
+
+
+    private:
+        QString mName;
+        int mClass = 0;
+        QList<Segment> mSegments;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_NET_H

--- a/parseagle/schematic/part.cpp
+++ b/parseagle/schematic/part.cpp
@@ -1,0 +1,28 @@
+#include <QtCore>
+#include "part.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Part::Part(const DomElement& root)
+{
+    mName = root.getAttributeAsString("name");
+    mLibrary = root.getAttributeAsString("library");
+    if (root.hasAttribute("library_urn")) {
+        mLibraryUrn = root.getAttributeAsString("library_urn");
+    }
+    mDeviceSet = root.getAttributeAsString("deviceset");
+    mDevice = root.getAttributeAsString("device");
+    if (root.hasAttribute("technology")) {
+        mTechnology = root.getAttributeAsString("technology");
+    }
+    if (root.hasAttribute("value")) {
+        mValue = root.getAttributeAsString("value");
+    }
+}
+
+Part::~Part() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/part.h
+++ b/parseagle/schematic/part.h
@@ -1,0 +1,41 @@
+#ifndef PARSEAGLE_PART_H
+#define PARSEAGLE_PART_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class Part final
+{
+    public:
+
+        // Constructors / Destructor
+        Part() = delete;
+        explicit Part(const DomElement& root);
+        ~Part() noexcept;
+
+        // Getters
+        const QString& getName() const noexcept {return mName;}
+        const QString& getLibrary() const noexcept {return mLibrary;}
+        const QString& getLibraryUrn() const noexcept {return mLibraryUrn;}
+        const QString& getDeviceSet() const noexcept {return mDeviceSet;}
+        const QString& getDevice() const noexcept {return mDevice;}
+        const QString& getTechnology() const noexcept {return mTechnology;}
+        const QString& getValue() const noexcept {return mValue;}
+
+
+    private:
+        QString mName;
+        QString mLibrary;
+        QString mLibraryUrn;
+        QString mDeviceSet;
+        QString mDevice;
+        QString mTechnology;
+        QString mValue;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_PART_H

--- a/parseagle/schematic/pinref.cpp
+++ b/parseagle/schematic/pinref.cpp
@@ -1,0 +1,18 @@
+#include <QtCore>
+#include "pinref.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+PinRef::PinRef(const DomElement& root)
+{
+    mPart = root.getAttributeAsString("part");
+    mGate = root.getAttributeAsString("gate");
+    mPin = root.getAttributeAsString("pin");
+}
+
+PinRef::~PinRef() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/pinref.h
+++ b/parseagle/schematic/pinref.h
@@ -1,0 +1,33 @@
+#ifndef PARSEAGLE_PINREF_H
+#define PARSEAGLE_PINREF_H
+
+#include <QtCore>
+
+namespace parseagle {
+
+class DomElement;
+
+class PinRef final
+{
+    public:
+
+        // Constructors / Destructor
+        PinRef() = delete;
+        explicit PinRef(const DomElement& root);
+        ~PinRef() noexcept;
+
+        // Getters
+        const QString& getPart() const noexcept {return mPart;}
+        const QString& getGate() const noexcept {return mGate;}
+        const QString& getPin() const noexcept {return mPin;}
+
+
+    private:
+        QString mPart;
+        QString mGate;
+        QString mPin;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_PINREF_H

--- a/parseagle/schematic/schematic.cpp
+++ b/parseagle/schematic/schematic.cpp
@@ -1,0 +1,70 @@
+#include <QtCore>
+#include "schematic.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Schematic::Schematic(const QString& filepath, QStringList* errors)
+{
+    QFile file(filepath);
+    if (!file.exists()) {
+        throw std::runtime_error("File does not exist: " + filepath.toStdString());
+    }
+    if (!file.open(QIODevice::ReadOnly)) {
+        throw std::runtime_error("Cannot open file " + filepath.toStdString() +
+                                 ": " + file.errorString().toStdString());
+    }
+    load(file.readAll(), errors);
+}
+
+Schematic::Schematic(const QByteArray& content, QStringList* errors)
+{
+    load(content, errors);
+}
+
+Schematic::~Schematic() noexcept
+{
+}
+
+void Schematic::load(const QByteArray& content, QStringList* errors) {
+    QDomDocument doc;
+    doc.implementation().setInvalidDataPolicy(QDomImplementation::ReturnNullNode);
+    QString errMsg;
+    if (!doc.setContent(content, &errMsg)) {
+        throw std::runtime_error(
+            "Error while parsing EAGLE schematic: " + errMsg.toStdString());
+    }
+    DomElement root(doc.documentElement());
+    DomElement drawing = root.getFirstChild("drawing");
+
+    if (drawing.hasChild("grid")) {
+        mGrid = Grid(drawing.getFirstChild("grid"));
+    }
+
+    DomElement schematic = drawing.getFirstChild("schematic");
+    if (schematic.hasChild("description")) {
+        mDescription = schematic.getFirstChild("description").getText();
+    }
+    if (schematic.hasChild("libraries")) {
+        foreach (const DomElement& child, schematic.getFirstChild("libraries").getChilds()) {
+            mLibraries.append(Library(child, errors));
+        }
+    }
+    if (schematic.hasChild("modules")) {
+        foreach (const DomElement& child, schematic.getFirstChild("modules").getChilds()) {
+            mModules.append(Module(child));
+        }
+    }
+    if (schematic.hasChild("parts")) {
+        foreach (const DomElement& child, schematic.getFirstChild("parts").getChilds()) {
+            mParts.append(Part(child));
+        }
+    }
+    if (schematic.hasChild("sheets")) {
+        foreach (const DomElement& child, schematic.getFirstChild("sheets").getChilds()) {
+            mSheets.append(Sheet(child, errors));
+        }
+    }
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/schematic.h
+++ b/parseagle/schematic/schematic.h
@@ -1,0 +1,46 @@
+#ifndef PARSEAGLE_SCHEMATIC_H
+#define PARSEAGLE_SCHEMATIC_H
+
+#include <QtCore>
+#include "../common/grid.h"
+#include "../library.h"
+#include "module.h"
+#include "part.h"
+#include "sheet.h"
+
+namespace parseagle {
+
+class Schematic final
+{
+    public:
+
+        // Constructors / Destructor
+        Schematic() = delete;
+        explicit Schematic(const QString& filepath, QStringList* errors = nullptr);
+        explicit Schematic(const QByteArray& content, QStringList* errors = nullptr);
+        ~Schematic() noexcept;
+
+        // Getters
+        const QString& getDescription() const noexcept {return mDescription;}
+        const Grid& getGrid() const noexcept {return mGrid;}
+        const QList<Library>& getLibraries() const noexcept {return mLibraries;}
+        const QList<Module>& getModules() const noexcept {return mModules;}
+        const QList<Part>& getParts() const noexcept {return mParts;}
+        const QList<Sheet>& getSheets() const noexcept {return mSheets;}
+
+
+    private:
+        void load(const QByteArray& content, QStringList* errors = nullptr);
+
+
+        QString mDescription;
+        Grid mGrid;
+        QList<Library> mLibraries;
+        QList<Module> mModules;
+        QList<Part> mParts;
+        QList<Sheet> mSheets;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_SCHEMATIC_H

--- a/parseagle/schematic/segment.cpp
+++ b/parseagle/schematic/segment.cpp
@@ -1,0 +1,31 @@
+#include <QtCore>
+#include "segment.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Segment::Segment(const DomElement& root, QStringList* errors)
+{
+  foreach (const DomElement& child, root.getChilds()) {
+      if (child.getTagName() == "pinref") {
+          mPinRefs.append(PinRef(child));
+      } else if (child.getTagName() == "wire") {
+          mWires.append(Wire(child));
+      } else if (child.getTagName() == "junction") {
+          mJunctions.append(Point{
+              child.getAttributeAsDouble("x"),
+              child.getAttributeAsDouble("y"),
+          });
+      } else if (child.getTagName() == "label") {
+          mLabels.append(Label(child));
+      } else  if (errors) {
+          errors->append("Unknown net segment child: " + child.getTagName());
+      }
+  }
+}
+
+Segment::~Segment() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/segment.h
+++ b/parseagle/schematic/segment.h
@@ -1,0 +1,39 @@
+#ifndef PARSEAGLE_SEGMENT_H
+#define PARSEAGLE_SEGMENT_H
+
+#include <QtCore>
+#include "../common/point.h"
+#include "../common/wire.h"
+#include "pinref.h"
+#include "label.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Segment final
+{
+    public:
+
+        // Constructors / Destructor
+        Segment() = delete;
+        explicit Segment(const DomElement& root, QStringList* errors = nullptr);
+        ~Segment() noexcept;
+
+        // Getters
+        const QList<PinRef>& getPinRefs() const noexcept {return mPinRefs;}
+        const QList<Wire>& getWires() const noexcept {return mWires;}
+        const QList<Point>& getJunctions() const noexcept {return mJunctions;}
+        const QList<Label>& getLabels() const noexcept {return mLabels;}
+
+
+    private:
+        QList<PinRef> mPinRefs;
+        QList<Wire> mWires;
+        QList<Point> mJunctions;
+        QList<Label> mLabels;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_SEGMENT_H

--- a/parseagle/schematic/sheet.cpp
+++ b/parseagle/schematic/sheet.cpp
@@ -1,0 +1,54 @@
+#include <QtCore>
+#include "sheet.h"
+#include "../common/domelement.h"
+
+namespace parseagle {
+
+Sheet::Sheet(const DomElement& root, QStringList* errors)
+{
+    foreach (const DomElement& child, root.getChilds()) {
+        if (child.getTagName() == "description") {
+            mDescription = child.getText();
+        } else if (child.getTagName() == "plain") {
+            foreach (const DomElement& plainChild, child.getChilds()) {
+                if (plainChild.getTagName() == "wire") {
+                    mWires.append(Wire(plainChild));
+                } else if (plainChild.getTagName() == "rectangle") {
+                    mRectangles.append(Rectangle(plainChild));
+                } else if (plainChild.getTagName() == "circle") {
+                    mCircles.append(Circle(plainChild));
+                } else if (plainChild.getTagName() == "polygon") {
+                    mPolygons.append(Polygon(plainChild, errors));
+                } else if (plainChild.getTagName() == "text") {
+                    mTexts.append(Text(plainChild, errors));
+                } else if (plainChild.getTagName() == "frame") {
+                    mFrames.append(Frame(plainChild));
+                } else if (plainChild.getTagName() == "dimension") {
+                    mDimensions.append(Dimension(plainChild));
+                } else if (errors) {
+                    errors->append("Unknown sheet plain child: " + plainChild.getTagName());
+                }
+            }
+        } else if (child.getTagName() == "instances") {
+            foreach (const DomElement& instanceChild, child.getChilds()) {
+                mInstances.append(Instance(instanceChild, errors));
+            }
+        } else if (child.getTagName() == "busses") {
+            foreach (const DomElement& busChild, child.getChilds()) {
+                mBuses.append(Bus(busChild));
+            }
+        } else if (child.getTagName() == "nets") {
+            foreach (const DomElement& netChild, child.getChilds()) {
+                mNets.append(Net(netChild, errors));
+            }
+        } else if (errors) {
+            errors->append("Unknown sheet child: " + child.getTagName());
+        }
+    }
+}
+
+Sheet::~Sheet() noexcept
+{
+}
+
+} // namespace parseagle

--- a/parseagle/schematic/sheet.h
+++ b/parseagle/schematic/sheet.h
@@ -1,0 +1,59 @@
+#ifndef PARSEAGLE_Sheet_H
+#define PARSEAGLE_Sheet_H
+
+#include <QtCore>
+#include "../common/wire.h"
+#include "../common/rectangle.h"
+#include "../common/circle.h"
+#include "../common/polygon.h"
+#include "../common/text.h"
+#include "../common/frame.h"
+#include "../common/dimension.h"
+#include "bus.h"
+#include "instance.h"
+#include "net.h"
+
+namespace parseagle {
+
+class DomElement;
+
+class Sheet final
+{
+    public:
+
+        // Constructors / Destructor
+        Sheet() = delete;
+        explicit Sheet(const DomElement& root, QStringList* errors = nullptr);
+        ~Sheet() noexcept;
+
+        // Getters
+        const QString& getDescription() const noexcept {return mDescription;}
+        const QList<Wire>& getWires() const noexcept {return mWires;}
+        const QList<Rectangle>& getRectangles() const noexcept {return mRectangles;}
+        const QList<Circle>& getCircles() const noexcept {return mCircles;}
+        const QList<Polygon>& getPolygons() const noexcept {return mPolygons;}
+        const QList<Text>& getTexts() const noexcept {return mTexts;}
+        const QList<Frame>& getFrames() const noexcept {return mFrames;}
+        const QList<Dimension>& getDimensions() const noexcept {return mDimensions;}
+        const QList<Instance>& getInstances() const noexcept {return mInstances;}
+        const QList<Bus>& getBuses() const noexcept {return mBuses;}
+        const QList<Net>& getNets() const noexcept {return mNets;}
+
+
+    private:
+        QString mDescription;
+        QList<Wire> mWires;
+        QList<Rectangle> mRectangles;
+        QList<Circle> mCircles;
+        QList<Polygon> mPolygons;
+        QList<Text> mTexts;
+        QList<Frame> mFrames;
+        QList<Dimension> mDimensions;
+        QList<Instance> mInstances;
+        QList<Bus> mBuses;
+        QList<Net> mNets;
+};
+
+} // namespace parseagle
+
+#endif // PARSEAGLE_SHEET_H

--- a/parseagle/symbol/pin.cpp
+++ b/parseagle/symbol/pin.cpp
@@ -9,8 +9,20 @@ Pin::Pin(const DomElement& root, QStringList* errors)
     mName = root.getAttributeAsString("name");
     mPosition.x = root.getAttributeAsDouble("x");
     mPosition.y = root.getAttributeAsDouble("y");
+    if (root.hasAttribute("visible")) {
+        mVisibility = parsePinVisibility(root.getAttributeAsString("visible"), errors);
+    }
     if (root.hasAttribute("length")) {
         mLength = parsePinLength(root.getAttributeAsString("length"), errors);
+    }
+    if (root.hasAttribute("direction")) {
+        mDirection = parsePinDirection(root.getAttributeAsString("direction"), errors);
+    }
+    if (root.hasAttribute("function")) {
+        mFunction = parsePinFunction(root.getAttributeAsString("function"), errors);
+    }
+    if (root.hasAttribute("swaplevel")) {
+        mSwapLevel = root.getAttributeAsInt("swaplevel");
     }
     if (root.hasAttribute("rot")) {
         mRotation = Rotation(root.getAttributeAsString("rot"));

--- a/parseagle/symbol/pin.h
+++ b/parseagle/symbol/pin.h
@@ -25,15 +25,23 @@ class Pin final
         // Getters
         QString getName() const noexcept {return mName;}
         const Point& getPosition() const noexcept {return mPosition;}
+        PinVisibility getVisibility() const noexcept {return mVisibility;}
         PinLength getLength() const noexcept {return mLength;}
         double getLengthInMillimeters() const noexcept;
+        PinDirection getDirection() const noexcept {return mDirection;}
+        PinFunction getFunction() const noexcept {return mFunction;}
+        int getSwapLevel() const noexcept {return mSwapLevel;}
         const Rotation& getRotation() const noexcept {return mRotation;}
 
 
     private:
         QString mName;
         Point mPosition;
+        PinVisibility mVisibility = PinVisibility::Both;
         PinLength mLength = PinLength::Long;
+        PinDirection mDirection = PinDirection::IO;
+        PinFunction mFunction = PinFunction::None;
+        int mSwapLevel = 0;
         Rotation mRotation;
 };
 

--- a/parseagle/symbol/symbol.cpp
+++ b/parseagle/symbol/symbol.cpp
@@ -17,11 +17,15 @@ Symbol::Symbol(const DomElement& root, QStringList* errors)
         } else if (child.getTagName() == "circle") {
             mCircles.append(Circle(child));
         } else if (child.getTagName() == "polygon") {
-            mPolygons.append(Polygon(child));
+            mPolygons.append(Polygon(child, errors));
         } else if (child.getTagName() == "text") {
             mTexts.append(Text(child, errors));
         } else if (child.getTagName() == "pin") {
             mPins.append(Pin(child, errors));
+        } else if (child.getTagName() == "frame") {
+            mFrames.append(Frame(child));
+        } else if (child.getTagName() == "dimension") {
+            mDimensions.append(Dimension(child));
         } else if (errors) {
             errors->append("Unknown symbol child: " + child.getTagName());
         }

--- a/parseagle/symbol/symbol.h
+++ b/parseagle/symbol/symbol.h
@@ -7,6 +7,8 @@
 #include "../common/circle.h"
 #include "../common/polygon.h"
 #include "../common/text.h"
+#include "../common/frame.h"
+#include "../common/dimension.h"
 #include "pin.h"
 
 namespace parseagle {
@@ -31,6 +33,8 @@ class Symbol final
         const QList<Polygon>& getPolygons() const noexcept {return mPolygons;}
         const QList<Text>& getTexts() const noexcept {return mTexts;}
         const QList<Pin>& getPins() const noexcept {return mPins;}
+        const QList<Frame>& getFrames() const noexcept {return mFrames;}
+        const QList<Dimension>& getDimensions() const noexcept {return mDimensions;}
 
 
     private:
@@ -42,6 +46,8 @@ class Symbol final
         QList<Polygon> mPolygons;
         QList<Text> mTexts;
         QList<Pin> mPins;
+        QList<Frame> mFrames;
+        QList<Dimension> mDimensions;
 };
 
 } // namespace parseagle


### PR DESCRIPTION
Adding all the types and attributes which are required for LibrePCB to implement an EAGLE project importer. All changes are backwards compatible.

Based on #5 and #6.