### PR TITLE
DomElement: Clarify the "attribute not found" error

### DIFF
--- a/parseagle/common/domelement.cpp
+++ b/parseagle/common/domelement.cpp
@@ -31,7 +31,9 @@ QString DomElement::getAttributeAsString(const QString& name) const
     if (mAttributes.contains(name)) {
         return mAttributes.value(name);
     } else {
-        throw std::runtime_error("Attribute not found: " + name.toStdString());
+        throw std::runtime_error(
+            QString("Attribute '%1' not found in XML element '%2'.")
+            .arg(name).arg(mName).toStdString());
     }
 }
 


### PR DESCRIPTION
Add more information to the error message to easily find the XML node which causes the error.