### PR TITLE
Add support for Qt6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,15 @@ on: [push, pull_request]
 jobs:
 
   qmake:
-    name: "qmake on ${{ matrix.image }}"
+    name: "qmake on ${{ matrix.container }}"
     runs-on: ubuntu-22.04
-    container:
-      image: "${{ matrix.image }}"
+    container: "${{ matrix.container }}"
     strategy:
       matrix:
         include:
-          - {image: "ubuntu:18.04", qt: "qt5-default"}
-          - {image: "ubuntu:20.04", qt: "qt5-default"}
-          - {image: "ubuntu:22.04", qt: "qtbase5-dev"}
+          - {container: "ubuntu:18.04", packages: "qt5-default qttools5-dev-tools"}
+          - {container: "ubuntu:20.04", packages: "qt5-default qttools5-dev-tools"}
+          - {container: "ubuntu:22.04", packages: "qtbase5-dev qttools5-dev-tools"}
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -21,24 +20,42 @@ jobs:
         run: |
           apt-get update &&
           apt-get install -y --no-install-recommends \
-            pkg-config g++ make \
-            ${{ matrix.qt }} qttools5-dev-tools
+            pkg-config g++ make ${{ matrix.packages }}
       - name: Run qmake
         run: qmake -r "QMAKE_CXXFLAGS=-std=c++11 -Werror"
       - name: Build
         run: make -j8
 
   cmake:
-    name: "cmake on ${{ matrix.image }}"
+    name: "cmake/${{ matrix.qt }} on ${{ matrix.container }}"
     runs-on: ubuntu-22.04
-    container:
-      image: "${{ matrix.image }}"
+    container: "${{ matrix.container }}"
     strategy:
       matrix:
         include:
-          - {image: "ubuntu:18.04", qt: "qt5-default"}
-          - {image: "ubuntu:20.04", qt: "qt5-default"}
-          - {image: "ubuntu:22.04", qt: "qtbase5-dev"}
+          - qt: qt5
+            container: "ubuntu:18.04"
+            packages: qt5-default qttools5-dev-tools
+          - qt: qt5
+            container: "ubuntu:20.04"
+            packages: qt5-default qttools5-dev-tools
+          - qt: qt5
+            container: "ubuntu:22.04"
+            packages: qtbase5-dev qttools5-dev-tools
+          - qt: qt6
+            container: "ubuntu:22.04"
+            packages: qt6-base-dev qt6-base-dev-tools
+          - qt: qt5-implicit
+            container: "ubuntu:22.04"
+            packages: qtbase5-dev qttools5-dev-tools qt6-base-dev qt6-base-dev-tools
+          - qt: qt5-explicit
+            container: "ubuntu:22.04"
+            packages: qtbase5-dev qttools5-dev-tools qt6-base-dev qt6-base-dev-tools
+            cmake_flags: "-DPARSEAGLE_QT_MAJOR_VERSION=5"
+          - qt: qt6-explicit
+            container: "ubuntu:22.04"
+            packages: qtbase5-dev qttools5-dev-tools qt6-base-dev qt6-base-dev-tools
+            cmake_flags: "-DPARSEAGLE_QT_MAJOR_VERSION=6"
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -47,11 +64,10 @@ jobs:
         run: |
           apt-get update &&
           apt-get install -y --no-install-recommends \
-            pkg-config g++ make cmake \
-            ${{ matrix.qt }} qttools5-dev-tools
+            pkg-config g++ make cmake ${{ matrix.packages }}
       - name: Show cmake version
         run: cmake --version
       - name: Run cmake
-        run: cmake -S .
+        run: cmake -S . ${{ matrix.cmake_flags }}
       - name: Build
         run: VERBOSE=1 cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,25 @@ project(parseagle
     VERSION 0.2.0
     LANGUAGES CXX)
 
-# Use C++11
-set(CMAKE_CXX_STANDARD 11)
+# If Qt version is not explicitly specified, automatically determine it
+if(NOT PARSEAGLE_QT_MAJOR_VERSION)
+    find_package(Qt NAMES Qt5 Qt6 REQUIRED COMPONENTS Core Xml)
+    set(PARSEAGLE_QT_MAJOR_VERSION ${Qt_VERSION_MAJOR})
+endif()
+set(PARSEAGLE_QT "Qt${PARSEAGLE_QT_MAJOR_VERSION}")
+
+# Use C++11 (Qt5) or C++17 (Qt6)
+if(PARSEAGLE_QT_MAJOR_VERSION EQUAL 6)
+    set(CMAKE_CXX_STANDARD 17)
+else()
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Find required Qt packages
-find_package(Qt5 5.2.0 COMPONENTS Core Xml REQUIRED)
+find_package(${PARSEAGLE_QT} REQUIRED COMPONENTS Core Xml)
+message(STATUS "Building parseagle with Qt ${${PARSEAGLE_QT}_VERSION}")
 
 # Export library
 add_library(parseagle STATIC
@@ -109,8 +121,8 @@ add_library(parseagle STATIC
 )
 target_link_libraries(parseagle
     # Qt
-    Qt5::Core
-    Qt5::Xml
+    ${PARSEAGLE_QT}::Core
+    ${PARSEAGLE_QT}::Xml
 )
 target_include_directories(parseagle INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a C++/Qt library for parsing XML files created by EAGLE.
 
 ## Build Systems
 
-The library provides both support for qmake and cmake.
+The library provides both support for qmake (Qt5) and cmake (Qt5/Qt6).
 
 ## Error Handling
 


### PR DESCRIPTION
- Support passing the `PARSEAGLE_QT_MAJOR_VERSION` variable to CMake to choose between Qt5 and Qt6. This is required because LibrePCB must specify the Qt version to use. If not passed, it is automatically detected (Qt5 preferred for backwards compatibility).
- Added a CMake `message()` to print the used Qt version (very useful for investigating problems)
- Added CI jobs to build & test with Qt6
- Updated README